### PR TITLE
Center correctly the svg of the dark-mode-switcher

### DIFF
--- a/components/dark-mode-switcher.module.scss
+++ b/components/dark-mode-switcher.module.scss
@@ -1,5 +1,6 @@
 .switcher {
   position: fixed;
+  display: flex;
   bottom: 2rem;
   right: 2rem;
 
@@ -15,6 +16,7 @@
 
   & svg {
     width: 1rem;
+    margin: auto;
   }
 
   @media (min-width: 34.375rem) {


### PR DESCRIPTION
### Description

The svg of the dark-mode-switcher is not correctly centered 

**Actual :**

<img width="226" alt="Capture d’écran 2021-06-09 à 11 47 23" src="https://user-images.githubusercontent.com/31687635/121332764-78527500-c918-11eb-8de2-12afe04854dc.png">

**Expected :** 

<img width="238" alt="Capture d’écran 2021-06-09 à 11 46 47" src="https://user-images.githubusercontent.com/31687635/121332681-61138780-c918-11eb-97d5-0922f180fddc.png">
